### PR TITLE
Android security 11.0.0 release 59

### DIFF
--- a/core/java/android/content/pm/parsing/ParsingPackageUtils.java
+++ b/core/java/android/content/pm/parsing/ParsingPackageUtils.java
@@ -21,6 +21,7 @@ import static android.content.pm.ActivityInfo.RESIZE_MODE_UNRESIZEABLE;
 import static android.content.pm.PackageManager.FEATURE_WATCH;
 import static android.content.pm.PackageManager.INSTALL_PARSE_FAILED_BAD_MANIFEST;
 import static android.content.pm.PackageManager.INSTALL_PARSE_FAILED_INCONSISTENT_CERTIFICATES;
+import static android.content.pm.PackageManager.INSTALL_PARSE_FAILED_MANIFEST_MALFORMED;
 import static android.content.pm.PackageManager.INSTALL_PARSE_FAILED_ONLY_COREAPP_ALLOWED;
 import static android.content.pm.PackageManager.INSTALL_PARSE_FAILED_RESOURCES_ARSC_COMPRESSED;
 import static android.content.pm.PackageManager.INSTALL_PARSE_FAILED_UNEXPECTED_EXCEPTION;
@@ -775,6 +776,13 @@ public class ParsingPackageUtils {
             return input.error(
                     INSTALL_PARSE_FAILED_BAD_MANIFEST,
                     "Combination <feature> tags are not valid"
+            );
+        }
+
+        if (ParsedPermissionUtils.declareDuplicatePermission(pkg)) {
+            return input.error(
+                    INSTALL_PARSE_FAILED_MANIFEST_MALFORMED,
+                    "Found duplicate permission with a different attribute value."
             );
         }
 

--- a/core/java/android/content/pm/parsing/component/ParsedPermissionUtils.java
+++ b/core/java/android/content/pm/parsing/component/ParsedPermissionUtils.java
@@ -22,6 +22,8 @@ import android.content.pm.parsing.ParsingPackage;
 import android.content.res.Resources;
 import android.content.res.TypedArray;
 import android.content.res.XmlResourceParser;
+import android.util.ArrayMap;
+import android.util.EventLog;
 import android.util.Slog;
 
 import com.android.internal.R;
@@ -32,6 +34,8 @@ import android.content.pm.parsing.result.ParseResult;
 import org.xmlpull.v1.XmlPullParserException;
 
 import java.io.IOException;
+import java.util.List;
+import java.util.Objects;
 
 /** @hide */
 public class ParsedPermissionUtils {
@@ -206,5 +210,50 @@ public class ParsedPermissionUtils {
 
         return ComponentParseUtils.parseAllMetaData(pkg, res, parser, tag, permissionGroup,
                 input);
+    }
+
+    /**
+     * Determines if a duplicate permission is malformed .i.e. defines different protection level
+     * or group.
+     */
+    private static boolean isMalformedDuplicate(ParsedPermission p1, ParsedPermission p2) {
+        // Since a permission tree is also added as a permission with normal protection
+        // level, we need to skip if the parsedPermission is a permission tree.
+        if (p1 == null || p2 == null || p1.isTree() || p2.isTree()) {
+            return false;
+        }
+
+        if (p1.getProtectionLevel() != p2.getProtectionLevel()) {
+            return true;
+        }
+        if (!Objects.equals(p1.getGroup(), p2.getGroup())) {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * @return {@code true} if the package declares malformed duplicate permissions.
+     */
+    public static boolean declareDuplicatePermission(@NonNull ParsingPackage pkg) {
+        final List<ParsedPermission> permissions = pkg.getPermissions();
+        final int size = permissions.size();
+        if (size > 0) {
+            final ArrayMap<String, ParsedPermission> checkDuplicatePerm = new ArrayMap<>(size);
+            for (int i = 0; i < size; i++) {
+                final ParsedPermission parsedPermission = permissions.get(i);
+                final String name = parsedPermission.getName();
+                final ParsedPermission perm = checkDuplicatePerm.get(name);
+                if (isMalformedDuplicate(parsedPermission, perm)) {
+                    // Fix for b/213323615
+                    EventLog.writeEvent(0x534e4554, "213323615",
+                            "The package " + pkg.getPackageName() + " seems malicious");
+                    return true;
+                }
+                checkDuplicatePerm.put(name, parsedPermission);
+            }
+        }
+        return false;
     }
 }

--- a/core/java/android/content/pm/parsing/component/ParsedPermissionUtils.java
+++ b/core/java/android/content/pm/parsing/component/ParsedPermissionUtils.java
@@ -247,8 +247,7 @@ public class ParsedPermissionUtils {
                 final ParsedPermission perm = checkDuplicatePerm.get(name);
                 if (isMalformedDuplicate(parsedPermission, perm)) {
                     // Fix for b/213323615
-                    EventLog.writeEvent(0x534e4554, "213323615",
-                            "The package " + pkg.getPackageName() + " seems malicious");
+                    EventLog.writeEvent(0x534e4554, "213323615");
                     return true;
                 }
                 checkDuplicatePerm.put(name, parsedPermission);

--- a/core/java/android/os/Parcel.java
+++ b/core/java/android/os/Parcel.java
@@ -443,6 +443,7 @@ public final class Parcel {
      */
     public final void recycle() {
         if (DEBUG_RECYCLE) mStack = null;
+        mClassCookies = null;
         freeBuffer();
 
         final Parcel[] pool;


### PR DESCRIPTION
Merge tag 'android-security-11.0.0_r59' of https://android.googlesource.com/platform/frameworks/base into arrow-11.0

Android security 11.0.0 release 59
Tag: https://android.googlesource.com/platform/frameworks/base/+/refs/tags/android-security-11.0.0_r59

Merge cherrypicks of [18083515, 18492305, 19101007, 19119301, 19139356] into security-aosp-rvc-release.

Change-Id: [Ia3bd118152ef68e027f20de700f5b1e8a8765555](https://android-review.googlesource.com/#/q/Ia3bd118152ef68e027f20de700f5b1e8a8765555)